### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/EsportServeƦ.yml
+++ b/.github/workflows/EsportServeƦ.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
        - name: Processing Esport ServeƦ
-         uses: actions/checkout@v3.0.2
+         uses: actions/checkout@v3.1.0
        - uses: actions/checkout@v2
          with:
           # Access token with `workflow` scope is required
@@ -34,7 +34,7 @@ jobs:
           # because GitHub Actions does not yet allow `Lists` as input
           ignore: '["actions/checkout@v2", "actions/cache@v2"]'
        
-       - uses: styfle/cancel-workflow-action@0.10.0
+       - uses: styfle/cancel-workflow-action@0.10.1
          name: "Checking Esport ServeƦ Runners"
          with:
             all_but_latest: true

--- a/.github/workflows/EsportServeƦ.yml
+++ b/.github/workflows/EsportServeƦ.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
        - name: Processing Esport ServeƦ
-         uses: actions/checkout@main
+         uses: actions/checkout@v3.0.2
        - uses: actions/checkout@v2
          with:
           # Access token with `workflow` scope is required
@@ -34,7 +34,7 @@ jobs:
           # because GitHub Actions does not yet allow `Lists` as input
           ignore: '["actions/checkout@v2", "actions/cache@v2"]'
        
-       - uses: styfle/cancel-workflow-action@0.9.0
+       - uses: styfle/cancel-workflow-action@0.10.0
          name: "Checking Esport ServeƦ Runners"
          with:
             all_but_latest: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v3.0.2](https://github.com/actions/checkout/releases/tag/v3.0.2) on 2022-04-21T14:56:58Z
* **[styfle/cancel-workflow-action](https://github.com/styfle/cancel-workflow-action)** published a new release [0.10.0](https://github.com/styfle/cancel-workflow-action/releases/tag/0.10.0) on 2022-06-27T03:02:39Z
